### PR TITLE
Add support for images and attachments again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,9 @@ RUN set -x && \
             php7-curl \
             php7-dom \
             php7-embed \
+            php7-fileinfo \
             php7-fpm \
+            php7-gd \
             php7-iconv \
             php7-imap \
             php7-json \


### PR DESCRIPTION
Add php7-fileinfo and php7-gd back in after they were (probably) [removed during a merge](https://github.com/tiredofit/docker-freescout/commit/592f2e521c1f4878ffc0e5465c12de8287a10f50).