### PR TITLE
Added option -n when creating admin user

### DIFF
--- a/install/etc/cont-init.d/30-freescout
+++ b/install/etc/cont-init.d/30-freescout
@@ -223,7 +223,7 @@ if [ $? -gt 0 ]; then
 	### Create User
 	print_warn "Creating Administrative User"
   cd ${NGINX_WEBROOT} 
-  sudo -u ${NGINX_USER} php artisan freescout:create-user --role=admin --firstName=${ADMIN_FIRST_NAME} --lastName=${ADMIN_LAST_NAME} --email=${ADMIN_EMAIL} --password=${ADMIN_PASS}
+  sudo -u ${NGINX_USER} php artisan -n freescout:create-user --role=admin --firstName=${ADMIN_FIRST_NAME} --lastName=${ADMIN_LAST_NAME} --email=${ADMIN_EMAIL} --password=${ADMIN_PASS}
 fi
 
 cd ${NGINX_WEBROOT}


### PR DESCRIPTION
The command php:artisan freescout:create-user uses a interactive shell which is not working in docker of course. Added an option -n for disabling the interactive shell. Tested and user is created properly.