### PR TITLE
Fix permissions when "Generating Configuration"

### DIFF
--- a/install/etc/cont-init.d/30-freescout
+++ b/install/etc/cont-init.d/30-freescout
@@ -147,6 +147,7 @@ if grep -q "APP_URL" "${NGINX_WEBROOT}"/.env > /dev/null 2>&1; then
 else
     print_info "Generating Configuration"
     touch "${NGINX_WEBROOT}"/.env
+    chown "${NGINX_USER}":"${NGINX_GROUP}" "${NGINX_WEBROOT}"/.env
     echo "#### Automatically Generated File - Upon container restart any settings will reset!" | sudo -u "${NGINX_USER}" tee "${NGINX_WEBROOT}"/.env
     # Proxy and HostSettings
     if [ -z "$SITE_URL" ]; then


### PR DESCRIPTION
File `.env` created by root user. Then lines appended to `.env` file under "${NGINX_USER}" and it fails with permission denied.