### PR TITLE
Fix for log not being saved permanently

### DIFF
--- a/install/etc/cont-init.d/30-freescout
+++ b/install/etc/cont-init.d/30-freescout
@@ -17,8 +17,6 @@ db_ready mariadb
 mkdir -p /www/logs/freescout
 chown -R "${NGINX_USER}":"${NGINX_GROUP}" /www/logs/freescout
 rm -rf "${NGINX_WEBROOT}"/storage/logs
-mkdir -p "${NGINX_WEBROOT}"/storage/logs
-chown -R "${NGINX_USER}":"${NGINX_GROUP}" "${NGINX_WEBROOT}"/storage/logs
 ln -sf /www/logs/freescout "${NGINX_WEBROOT}"/storage/logs
 
 ### Check if New Install


### PR DESCRIPTION
The logs directory is redirected to `/www/html/storage/logs/freescout` instead of the expected `/www/html/storage/logs`.

**Before pull request**

```
bash-5.0# ls -la                                                                                                                 total 12                                                        
drwxr-xr-x    2 nginx    www-data      4096 Feb 14 14:30 .                                                                       
drwxrwxr-x    6 nginx    www-data      4096 Feb 14 14:27 .. 
-rw-r--r--    1 nginx    www-data       106 Feb 14 14:40 fetch-emails.log                                                        
lrwxrwxrwx    1 root     root            19 Feb 14 14:27 freescout -> /www/logs/freescout
-rw-r--r--    1 nginx    www-data         0 Feb 14 14:30 queue-jobs.log
```

**After pull request**
```
bash-5.0# rm -rf /www/html/storage/logs/
bash-5.0# ln -sf /www/logs/freescout/ /www/html/storage/logs
bash-5.0# ls -la /www/html/storage/logs
lrwxrwxrwx    1 root     root            20 Feb 14 14:45 /www/html/storage/logs -> /www/logs/freescout/
```
By doing this, the file will be saved in `/www/logs/freescout/`, which is the path where it is supposed to be saved permanently.
```
bash-5.0# ls -l /www/logs/freescout/
total 4
-rw-r--r--    1 nginx    www-data       106 Feb 14 14:53 fetch-emails.log
```