### PR TITLE
use https for letsencrypt proxy companion

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     - SITE_URL=https://freescout.example.com
     - ADMIN_EMAIL=admin@admin.com
     - ADMIN_PASS=freescout
-    - ENABLE_SSL_PROXY=FALSE
+    - ENABLE_SSL_PROXY=TRUE
     - DISPLAY_ERRORS=FALSE
     - TIMEZONE=America/Vancouver
     networks:


### PR DESCRIPTION
The example includes environment variables for the `jrcs/letsencrypt-nginx-proxy-companion`, but does not enable https for FreeScout — SSL errors are given in the browser for mixed content.