### PR TITLE
fix: removed invalid tab on EOF

### DIFF
--- a/install/etc/cont-init.d/30-freescout
+++ b/install/etc/cont-init.d/30-freescout
@@ -271,7 +271,7 @@ if [ ! -f "/tmp/.container/container-restart" ] ; then
         sudo -u ${NGINX_USER} php artisan "\$@"
         cd "\${oldpwd}"
     }
-    EOF
+EOF
 fi
 
 cd "${NGINX_WEBROOT}"


### PR DESCRIPTION
This hopefully fixes the `/etc/cont-init.d/30-freescout: line 290: syntax error: unexpected end of file`