### PR TITLE
Configure gzip in nginx server.

### DIFF
--- a/install/etc/nginx/sites.available/freescout.conf
+++ b/install/etc/nginx/sites.available/freescout.conf
@@ -3,6 +3,15 @@ server {
   listen {{NGINX_LISTEN_PORT}};
   root {{NGINX_WEBROOT}}/public;
   index index.php ;
+  
+  # enable gzip to reduce transfer size for JS/CSS files (etc
+  gzip on;
+  gzip_vary on;
+  gzip_comp_level 7;
+  gzip_min_length 512;
+  gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
+  gzip_types application/javascript application/json application/ld+json application/manifest+json application/rss+xml   application/x-font-ttf application/xhtml+xml application/xml image/svg+xml  text/css text/plain text/vcard text/vtt text/x-component text/x-cross-domain-policy;
+
 
   location / {
       try_files $uri $uri/ /index.php?$query_string;


### PR DESCRIPTION
This should improve responsiveness when client connections are slow (for example on mobile/cell or office/shared wifi).

I haven't had a chance to test this locally, but would appreciate your feedback.