### PR TITLE
Fix sed typo

### DIFF
--- a/install/etc/cont-init.d/30-freescout
+++ b/install/etc/cont-init.d/30-freescout
@@ -230,7 +230,7 @@ fi
 
 ## Removals
 # 1.8.78
-sed -i --follow-symlinks "APP_FORCE_HTTP=/d" "${NGINX_WEBROOT}"/.env
+sed -i --follow-symlinks "/APP_FORCE_HTTP=/d" "${NGINX_WEBROOT}"/.env
 
 ### Cleanup
 cd "${NGINX_WEBROOT}"/


### PR DESCRIPTION
b0e85fc is missing a `/` at the start of the search pattern:
```
sed -i --follow-symlinks "APP_FORCE_HTTP=/d" "${NGINX_WEBROOT}"/.env
```

Which currently causes the following error on startup:
```
sed: -e expression #1, char 1: unknown command: `A'
```