### PR TITLE
Set proxy-tier.name and proxy-tier.external to true

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -81,7 +81,7 @@ services:
 
 networks:
   proxy-tier:
-    external:
-      name: nginx-proxy
+    external: true
+    name: nginx-proxy
 
 


### PR DESCRIPTION
Brings file up to current standard. networks.proxy-tier: external.name is deprecated.