### PR TITLE
Fix documentation of APP_NEW_FETCHING_LIBRARY

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Be sure to view the following repositories to understand all the customizable op
 | `APPLICATION_NAME`         | Change default application name - Default `Freescout`                                           | `freescout` |         |
 | `APP_PROXY`                | Allow Application to use a proxy for fetching modules                                           |             |         |
 | `APP_TRUSTED_PROXIES`      | Comma separated list of trusted proxies, i.e. `192.168.1.1,192.168.1.2,192.168.1.3`             |             |         |
-| `APP_NEW_FETCHING_LIBRARY` | Sets FreeScout's new_fetching_library config option                                             | `FALSE`     |         |
+| `APP_NEW_FETCHING_LIBRARY` | Sets FreeScout's new_fetching_library config option                                             | `TRUE`      |         |
 | `APP_X_FRAME_OPTIONS`      | Allow to embed via iframes `TRUE` `FALSE` `DENY` `ALLOW FROM example.org`                       | `TRUE`
 | `DB_TYPE`                  | Type of the Database. Currently supported are `mysql` and `pgsql`                               | `mysql`     |         |
 | `DB_PGSQL_SSL_MODE`        | Postgresql TLS Mode                                                                             | `prefer`    |         |


### PR DESCRIPTION
The parameter documentation in README.md is not correct.

It says APP_NEW_FETCHING_LIBRARY is FALSE by default, but it actually have been TRUE since image version 1.17.72, but README.md has not been updated.

See https://github.com/tiredofit/docker-freescout/commit/21ed319e2485fed429aa7a56a88ee0aaaee7e623