### PR TITLE
Fix APP_X_FRAME_OPTIONS boolean value

### DIFF
--- a/install/etc/cont-init.d/30-freescout
+++ b/install/etc/cont-init.d/30-freescout
@@ -158,9 +158,9 @@ if grep -q "APP_URL" "${NGINX_WEBROOT}"/.env > /dev/null 2>&1; then
         fi
 
         if ! grep -q "APP_X_FRAME_OPTIONS" "${NGINX_WEBROOT}"/.env > /dev/null 2>&1; then
-            echo "APP_X_FRAME_OPTIONS=${APP_X_FRAME_OPTIONS}" | sudo -u "${NGINX_USER}" tee -a "${NGINX_WEBROOT}"/.env
+            echo "APP_X_FRAME_OPTIONS=${APP_X_FRAME_OPTIONS,,}" | sudo -u "${NGINX_USER}" tee -a "${NGINX_WEBROOT}"/.env
         else
-            sed -i --follow-symlinks "s#APP_X_FRAME_OPTIONS=.*#APP_X_FRAME_OPTIONS=${APP_X_FRAME_OPTIONS}#g" "${NGINX_WEBROOT}"/.env
+            sed -i --follow-symlinks "s#APP_X_FRAME_OPTIONS=.*#APP_X_FRAME_OPTIONS=${APP_X_FRAME_OPTIONS,,}#g" "${NGINX_WEBROOT}"/.env
         fi
     else
         print_info "Skipping Auto configuration and using in place .env"


### PR DESCRIPTION
Convert the value of APP_X_FRAME_OPTIONS to lower case, because Freescout only accepts `true` and `false` in lower case, but in README.md it is document as upper case (`TRUE` or `FALSE`).

https://github.com/freescout-help-desk/freescout/blob/master/app/Http/Middleware/FrameGuard.php#L16

All other values like ALLOW, DENY and ALLOW-FROM (deprecated by most browsers) will also be converted to lower case, but are not case-sensitive in modern browsers and will still work:

Chromium:
https://github.com/chromium/chromium/blob/master/services/network/public/cpp/x_frame_options_parser.cc#L30

Firefox:
https://github.com/mozilla/gecko-dev/blob/master/dom/security/FramingChecker.cpp#L165

WebKit
https://github.com/WebKit/WebKit/blob/main/Source/WebCore/platform/network/HTTPParsers.cpp#L568