### PR TITLE
Actually use FreeScout v1.8.177

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="Dave Conroy (github.com/tiredofit)"
 
 ARG FREESCOUT_VERSION
 
-ENV FREESCOUT_VERSION=${FREESCOUT_VERSION:-"1.8.176"} \
+ENV FREESCOUT_VERSION=${FREESCOUT_VERSION:-"1.8.177"} \
     FREESCOUT_REPO_URL=https://github.com/freescout-helpdesk/freescout \
     NGINX_WEBROOT=/www/html \
     NGINX_SITE_ENABLED=freescout \


### PR DESCRIPTION
This change was missing in the https://github.com/tiredofit/docker-freescout/commit/4b95ec3e6373fc9ead2a3df56ccf8fd80f61bfb1