### PR TITLE
do not chown everything recursively

### DIFF
--- a/install/etc/cont-init.d/30-freescout
+++ b/install/etc/cont-init.d/30-freescout
@@ -313,7 +313,7 @@ if var_false "${SKIP_STORAGE_PERMISSIONS}" ; then
   chmod -R ug+rwx storage
 fi
 
-chown -R "${NGINX_USER}":"${NGINX_GROUP}" "${NGINX_WEBROOT}"
+chown "${NGINX_USER}":"${NGINX_GROUP}" "${NGINX_WEBROOT}"
 chmod ug+rwx "${NGINX_WEBROOT}"
 
 ### Install symlinks for modules that may have been previously installed


### PR DESCRIPTION
logical error to recursively chown everything, especially when we set SKIP_STORAGE_PERMISSIONS=true (because $NGINX_WEBROOT contains storage/).

we have already chown'ed the specific dirs we need a few lines above.